### PR TITLE
Add AWS S3 Maven dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,19 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<aws.sdk.version>2.25.60</aws.sdk.version>
 	</properties>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>${aws.sdk.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -45,6 +57,10 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
### Motivation
- Prepare the project for upcoming S3-backed file storage work by adding the AWS SDK S3 client dependency and centralized version management. 
- Keep changes minimal and isolated to dependency configuration so existing auth, JWT, CORS, security, user logic and application properties remain untouched.

### Description
- Added a new Maven property `aws.sdk.version` and declared the AWS SDK BOM under `dependencyManagement` in `pom.xml` to control SDK versions with a single property. 
- Added the `software.amazon.awssdk:s3` dependency to the `dependencies` section of `pom.xml` so S3 client APIs will be available for future tasks. 
- Only `pom.xml` was modified and no Java source, configuration properties, or documentation files were changed.

### Testing
- Ran `git diff --check` which passed with no whitespace errors. 
- Attempted `./mvnw test` but it could not run because the wrapper is not executable in this environment. 
- Attempted `mvn test` but the build could not complete because Maven Central returned HTTP 403 while resolving the Spring Boot parent POM in this environment, so full dependency resolution/tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02256cef948321b5aff20aca32d960)