### PR TITLE
Add file metadata Mongo model and repository

### DIFF
--- a/src/main/java/com/craft/userservice/file/dto/FileMetadataResponseDto.java
+++ b/src/main/java/com/craft/userservice/file/dto/FileMetadataResponseDto.java
@@ -1,0 +1,28 @@
+package com.craft.userservice.file.dto;
+
+import java.time.Instant;
+
+import com.craft.userservice.file.enums.FileStorageStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FileMetadataResponseDto {
+    private String id;
+    private String uploadedByUserId;
+    private String originalFilename;
+    private String contentType;
+    private Long size;
+    private String bucket;
+    private String s3Key;
+    private String publicUrl;
+    private FileStorageStatus status;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/com/craft/userservice/file/enums/FileStorageStatus.java
+++ b/src/main/java/com/craft/userservice/file/enums/FileStorageStatus.java
@@ -1,0 +1,8 @@
+package com.craft.userservice.file.enums;
+
+public enum FileStorageStatus {
+    PENDING,
+    UPLOADED,
+    FAILED,
+    DELETED
+}

--- a/src/main/java/com/craft/userservice/file/model/FileMetadata.java
+++ b/src/main/java/com/craft/userservice/file/model/FileMetadata.java
@@ -1,0 +1,37 @@
+package com.craft.userservice.file.model;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import com.craft.userservice.file.enums.FileStorageStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Document(collection = "file_metadata")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FileMetadata {
+    @Id
+    private String id;
+
+    @Indexed
+    private String uploadedByUserId;
+    private String originalFilename;
+    private String contentType;
+    private Long size;
+    private String bucket;
+    @Indexed(unique = true)
+    private String s3Key;
+    private String publicUrl;
+    private FileStorageStatus status;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/com/craft/userservice/file/repository/FileMetadataRepository.java
+++ b/src/main/java/com/craft/userservice/file/repository/FileMetadataRepository.java
@@ -1,0 +1,9 @@
+package com.craft.userservice.file.repository;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import com.craft.userservice.file.model.FileMetadata;
+
+public interface FileMetadataRepository extends MongoRepository<FileMetadata, String> {
+
+}


### PR DESCRIPTION
## Summary
- add `FileMetadata` MongoDB document for uploaded file metadata only
- add `FileMetadataRepository` for Spring Data MongoDB access
- add `FileStorageStatus` enum and `FileMetadataResponseDto`

## Scope
- no upload endpoint
- no S3 upload service
- no auth, JWT, CORS, security, user logic, application.properties, or pom.xml changes

## Testing
- Not run; repository was updated through GitHub without a local checkout in this workspace.