### PR TITLE
Add file upload REST endpoint

### DIFF
--- a/src/main/java/com/craft/userservice/file/controller/FileController.java
+++ b/src/main/java/com/craft/userservice/file/controller/FileController.java
@@ -1,0 +1,53 @@
+package com.craft.userservice.file.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.craft.userservice.file.dto.FileMetadataResponseDto;
+import com.craft.userservice.file.exception.FileStorageException;
+import com.craft.userservice.file.service.FileStorageService;
+import com.craft.userservice.user.model.User;
+import com.craft.userservice.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/files")
+@RequiredArgsConstructor
+public class FileController {
+    private final FileStorageService fileStorageService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/upload")
+    public ResponseEntity<?> uploadFile(@RequestParam("file") MultipartFile file, Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+        }
+
+        try {
+            String email = (String) authentication.getPrincipal();
+            User user = userRepository.findByEmail(email).orElse(null);
+            if (user == null) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+            }
+
+            FileMetadataResponseDto responseDto = fileStorageService.uploadFile(file, user.getId());
+            return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+        } catch (FileStorageException e) {
+            HttpStatus status = isStorageFailure(e) ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.BAD_REQUEST;
+            return ResponseEntity.status(status).body(e.getMessage());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal server error");
+        }
+    }
+
+    private boolean isStorageFailure(FileStorageException exception) {
+        return exception.getCause() != null;
+    }
+}


### PR DESCRIPTION
## Summary
- add `FileController` with `POST /api/files/upload`
- accept multipart request parameter named `file`
- resolve the authenticated user's email from the existing authentication principal, look up the user id, and call `FileStorageService`
- return `FileMetadataResponseDto` with `201 Created` after successful upload

## Error handling
- returns `401 Unauthorized` when no authenticated user can be resolved
- maps validation `FileStorageException`s to `400 Bad Request`
- maps storage failures and unexpected errors to `500 Internal Server Error`

## Scope
- no download endpoint
- no delete endpoint
- no auth, JWT, CORS, security, or user logic changes
- no `application.properties` or `pom.xml` changes

## Testing
- Not run; repository was updated through GitHub without a local checkout in this workspace.