### PR TITLE
Add presigned file download URL endpoint

### DIFF
--- a/src/main/java/com/craft/userservice/file/configuration/S3Config.java
+++ b/src/main/java/com/craft/userservice/file/configuration/S3Config.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 @EnableConfigurationProperties(S3Properties.class)
@@ -14,6 +15,14 @@ public class S3Config {
     @Bean
     public S3Client s3Client(S3Properties s3Properties) {
         return S3Client.builder()
+                .region(Region.of(s3Properties.getRegion()))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(S3Properties s3Properties) {
+        return S3Presigner.builder()
                 .region(Region.of(s3Properties.getRegion()))
                 .credentialsProvider(DefaultCredentialsProvider.create())
                 .build();

--- a/src/main/java/com/craft/userservice/file/controller/FileController.java
+++ b/src/main/java/com/craft/userservice/file/controller/FileController.java
@@ -1,28 +1,45 @@
 package com.craft.userservice.file.controller;
 
+import java.time.Duration;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.craft.userservice.file.dto.FileDownloadUrlResponseDto;
 import com.craft.userservice.file.dto.FileMetadataResponseDto;
 import com.craft.userservice.file.exception.FileStorageException;
+import com.craft.userservice.file.model.FileMetadata;
+import com.craft.userservice.file.repository.FileMetadataRepository;
 import com.craft.userservice.file.service.FileStorageService;
 import com.craft.userservice.user.model.User;
 import com.craft.userservice.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @RestController
 @RequestMapping("/api/files")
 @RequiredArgsConstructor
 public class FileController {
+    private static final Duration DOWNLOAD_URL_EXPIRATION = Duration.ofMinutes(10);
+
     private final FileStorageService fileStorageService;
     private final UserRepository userRepository;
+    private final FileMetadataRepository fileMetadataRepository;
+    private final S3Presigner s3Presigner;
 
     @PostMapping("/upload")
     public ResponseEntity<?> uploadFile(@RequestParam("file") MultipartFile file, Authentication authentication) {
@@ -44,6 +61,54 @@ public class FileController {
             return ResponseEntity.status(status).body(e.getMessage());
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal server error");
+        }
+    }
+
+    @GetMapping("/{id}/download-url")
+    public ResponseEntity<?> getDownloadUrl(@PathVariable String id, Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+        }
+
+        String email = (String) authentication.getPrincipal();
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+        }
+
+        FileMetadata metadata = fileMetadataRepository.findById(id).orElse(null);
+        if (metadata == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("File not found");
+        }
+
+        if (!user.getId().equals(metadata.getUploadedByUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Forbidden");
+        }
+
+        if (!StringUtils.hasText(metadata.getBucket()) || !StringUtils.hasText(metadata.getS3Key())) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("File storage metadata is incomplete");
+        }
+
+        try {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(metadata.getBucket())
+                    .key(metadata.getS3Key())
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(DOWNLOAD_URL_EXPIRATION)
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
+            PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+
+            return ResponseEntity.ok(FileDownloadUrlResponseDto.builder()
+                    .id(metadata.getId())
+                    .originalFilename(metadata.getOriginalFilename())
+                    .downloadUrl(presignedRequest.url().toString())
+                    .build());
+        } catch (SdkClientException e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Could not generate download URL");
         }
     }
 

--- a/src/main/java/com/craft/userservice/file/dto/FileDownloadUrlResponseDto.java
+++ b/src/main/java/com/craft/userservice/file/dto/FileDownloadUrlResponseDto.java
@@ -1,0 +1,16 @@
+package com.craft.userservice.file.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FileDownloadUrlResponseDto {
+    private String id;
+    private String originalFilename;
+    private String downloadUrl;
+}


### PR DESCRIPTION
## Summary
- add an `S3Presigner` bean using the existing S3 configuration and AWS default credentials provider chain
- add `GET /api/files/{id}/download-url`
- return file id, original filename, and a 10-minute presigned S3 GET URL

## Behavior
- 401 when the request is unauthenticated or the authenticated user cannot be resolved
- 404 when file metadata does not exist
- 403 when the authenticated user is not the file owner
- 500 when stored S3 metadata is incomplete or a presigned URL cannot be generated

## Scope
- no upload endpoint logic changes
- no auth, JWT, CORS, security, or user logic changes
- S3 bucket remains private; access is via temporary presigned URL only

## Tests
- Not run; change was made through GitHub file updates in this environment.