### PR TITLE
Add authenticated file delete endpoint

### DIFF
--- a/src/main/java/com/craft/userservice/file/controller/FileController.java
+++ b/src/main/java/com/craft/userservice/file/controller/FileController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.craft.userservice.file.dto.FileDownloadUrlResponseDto;
 import com.craft.userservice.file.dto.FileMetadataResponseDto;
+import com.craft.userservice.file.enums.FileStorageStatus;
 import com.craft.userservice.file.exception.FileStorageException;
 import com.craft.userservice.file.model.FileMetadata;
 import com.craft.userservice.file.repository.FileMetadataRepository;
@@ -80,6 +82,7 @@ public class FileController {
         List<FileMetadataResponseDto> files = fileMetadataRepository
                 .findByUploadedByUserIdOrderByCreatedAtDesc(user.getId())
                 .stream()
+                .filter(metadata -> metadata.getStatus() != FileStorageStatus.DELETED)
                 .map(this::toResponseDto)
                 .toList();
 
@@ -99,7 +102,7 @@ public class FileController {
         }
 
         FileMetadata metadata = fileMetadataRepository.findById(id).orElse(null);
-        if (metadata == null) {
+        if (metadata == null || metadata.getStatus() == FileStorageStatus.DELETED) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body("File not found");
         }
 
@@ -131,6 +134,36 @@ public class FileController {
                     .build());
         } catch (SdkClientException e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Could not generate download URL");
+        }
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteFile(@PathVariable String id, Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+        }
+
+        String email = (String) authentication.getPrincipal();
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+        }
+
+        FileMetadata metadata = fileMetadataRepository.findById(id).orElse(null);
+        if (metadata == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("File not found");
+        }
+
+        if (!user.getId().equals(metadata.getUploadedByUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Forbidden");
+        }
+
+        try {
+            fileStorageService.deleteFile(metadata);
+            return ResponseEntity.noContent().build();
+        } catch (FileStorageException e) {
+            HttpStatus status = isStorageFailure(e) ? HttpStatus.INTERNAL_SERVER_ERROR : HttpStatus.BAD_REQUEST;
+            return ResponseEntity.status(status).body(e.getMessage());
         }
     }
 

--- a/src/main/java/com/craft/userservice/file/service/FileStorageService.java
+++ b/src/main/java/com/craft/userservice/file/service/FileStorageService.java
@@ -3,7 +3,10 @@ package com.craft.userservice.file.service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.craft.userservice.file.dto.FileMetadataResponseDto;
+import com.craft.userservice.file.model.FileMetadata;
 
 public interface FileStorageService {
     FileMetadataResponseDto uploadFile(MultipartFile file, String uploadedByUserId);
+
+    void deleteFile(FileMetadata metadata);
 }

--- a/src/main/java/com/craft/userservice/file/service/S3FileStorageService.java
+++ b/src/main/java/com/craft/userservice/file/service/S3FileStorageService.java
@@ -21,6 +21,7 @@ import com.craft.userservice.file.repository.FileMetadataRepository;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -78,6 +79,32 @@ public class S3FileStorageService implements FileStorageService {
 
         FileMetadata savedMetadata = fileMetadataRepository.save(metadata);
         return toResponseDto(savedMetadata);
+    }
+
+    @Override
+    public void deleteFile(FileMetadata metadata) {
+        if (metadata == null) {
+            throw new FileStorageException("File metadata is required.");
+        }
+
+        if (!StringUtils.hasText(metadata.getBucket()) || !StringUtils.hasText(metadata.getS3Key())) {
+            throw new FileStorageException("File storage metadata is incomplete.");
+        }
+
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(metadata.getBucket())
+                    .key(metadata.getS3Key())
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (S3Exception | SdkClientException ex) {
+            throw new FileStorageException("Could not delete file. Please try again later.", ex);
+        }
+
+        metadata.setStatus(FileStorageStatus.DELETED);
+        metadata.setUpdatedAt(Instant.now());
+        fileMetadataRepository.save(metadata);
     }
 
     private void validateUploadRequest(MultipartFile file, String uploadedByUserId) {


### PR DESCRIPTION
## Summary
- add `DELETE /api/files/{id}` with authentication, ownership, not-found, and forbidden handling
- delete the private S3 object through `S3Client.deleteObject`
- soft-delete Mongo metadata by setting `FileStorageStatus.DELETED` and refreshing `updatedAt`
- keep deleted files out of `GET /api/files/my` and block download URL generation for deleted files

## Testing
- Not run: local workspace did not contain a checkout/buildable project; changes were reviewed from GitHub branch source.