### PR TITLE
[codex] Validate upload content types

### DIFF
--- a/src/main/java/com/craft/userservice/file/service/S3FileStorageService.java
+++ b/src/main/java/com/craft/userservice/file/service/S3FileStorageService.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.Set;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
@@ -28,6 +29,11 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 @Service
 public class S3FileStorageService implements FileStorageService {
     private static final long BYTES_PER_MB = 1024L * 1024L;
+    private static final Set<String> ALLOWED_CONTENT_TYPES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+            "application/pdf");
 
     private final S3Client s3Client;
     private final S3Properties s3Properties;
@@ -127,6 +133,15 @@ public class S3FileStorageService implements FileStorageService {
 
         if (file.getSize() > maxFileSizeBytes) {
             throw new FileStorageException("File size exceeds the configured maximum.");
+        }
+
+        String contentType = file.getContentType();
+        if (!StringUtils.hasText(contentType)) {
+            throw new FileStorageException("File content type is required.");
+        }
+
+        if (!ALLOWED_CONTENT_TYPES.contains(contentType)) {
+            throw new FileStorageException("File content type is not supported.");
         }
     }
 

--- a/src/test/java/com/craft/userservice/file/service/S3FileStorageServiceTest.java
+++ b/src/test/java/com/craft/userservice/file/service/S3FileStorageServiceTest.java
@@ -27,10 +27,6 @@ import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 
-/**
- * Service-layer tests only. TODO: add content-type validation tests when
- * S3FileStorageService validates allowed content types.
- */
 @ExtendWith(MockitoExtension.class)
 class S3FileStorageServiceTest {
     private static final String BUCKET = "test-bucket";
@@ -84,6 +80,36 @@ class S3FileStorageServiceTest {
         assertThatThrownBy(() -> uploadFile(file))
                 .isInstanceOf(runtimeException("com.craft.userservice.file.exception.FileStorageException"))
                 .hasMessage("File size exceeds the configured maximum.");
+
+        verifyNoInteractions(s3Client, fileMetadataRepository);
+    }
+
+    @Test
+    void uploadFile_whenContentTypeIsUnsupported_fails() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "notes.txt",
+                "text/plain",
+                "not allowed".getBytes());
+
+        assertThatThrownBy(() -> uploadFile(file))
+                .isInstanceOf(runtimeException("com.craft.userservice.file.exception.FileStorageException"))
+                .hasMessage("File content type is not supported.");
+
+        verifyNoInteractions(s3Client, fileMetadataRepository);
+    }
+
+    @Test
+    void uploadFile_whenContentTypeIsMissing_fails() throws Exception {
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "photo.png",
+                null,
+                "image bytes".getBytes());
+
+        assertThatThrownBy(() -> uploadFile(file))
+                .isInstanceOf(runtimeException("com.craft.userservice.file.exception.FileStorageException"))
+                .hasMessage("File content type is required.");
 
         verifyNoInteractions(s3Client, fileMetadataRepository);
     }


### PR DESCRIPTION
## Summary

- Add an upload content-type allow list for JPEG, PNG, WebP, and PDF files.
- Reject missing or unsupported upload content types with safe `FileStorageException` messages before S3 or metadata work.
- Add service-layer tests for unsupported and missing content types without real AWS S3 or MongoDB calls.

## Validation

- `mvn -Dtest=S3FileStorageServiceTest test`