### PR TITLE
[codex] Add file metadata lookup endpoint

### DIFF
--- a/src/main/java/com/craft/userservice/file/controller/FileController.java
+++ b/src/main/java/com/craft/userservice/file/controller/FileController.java
@@ -89,6 +89,30 @@ public class FileController {
         return ResponseEntity.ok(files);
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getFileMetadata(@PathVariable String id, Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+        }
+
+        String email = (String) authentication.getPrincipal();
+        User user = userRepository.findByEmail(email).orElse(null);
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Unauthorized");
+        }
+
+        FileMetadata metadata = fileMetadataRepository.findById(id).orElse(null);
+        if (metadata == null || metadata.getStatus() == FileStorageStatus.DELETED) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("File not found");
+        }
+
+        if (!user.getId().equals(metadata.getUploadedByUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Forbidden");
+        }
+
+        return ResponseEntity.ok(toResponseDto(metadata));
+    }
+
     @GetMapping("/{id}/download-url")
     public ResponseEntity<?> getDownloadUrl(@PathVariable String id, Authentication authentication) {
         if (authentication == null || authentication.getPrincipal() == null) {


### PR DESCRIPTION
## Summary

- Add `GET /api/files/{id}` to return `FileMetadataResponseDto` for one uploaded file.
- Reuse the existing authentication, deleted-file, and ownership checks from the file controller.
- Avoid presigned URL generation and file content access in the metadata endpoint.

## Validation

- `mvn test` attempted, but the existing `UsersServiceApplicationTests` fails because Spring Boot cannot find a `@SpringBootConfiguration` from its package.
- `mvn -Dtest=S3FileStorageServiceTest test` passes.